### PR TITLE
resource ids should always be strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ export default class Client {
 
     if (resource) {
       if (resource.id) {
-        result.data.id = resource.id
+        result.data.id = resource.id.toString()
       }
       result.data.attributes = {}
 


### PR DESCRIPTION
Not a huge deal, just ran into some problems sending requests to an API that strictly enforced json:api

https://jsonapi.org/format/#document-resource-object-identification